### PR TITLE
Visual mode color change

### DIFF
--- a/after/plugin/neatstatus.vim
+++ b/after/plugin/neatstatus.vim
@@ -228,6 +228,8 @@ if has('statusline')
 
     endfunc
 
+    " Set visual mode color upon keypress since there are no events mapping to
+    " entering/exiting visual mode.
     vnoremap <silent> <expr> <SID>SetVisualModeColor SetVisualModeColor()
     nnoremap <silent> <script> v v<SID>SetVisualModeColor
     nnoremap <silent> <script> V V<SID>SetVisualModeColor


### PR DESCRIPTION
I have added code to fix mode color changes for visual mode. Unfortunately, there are no convenient events like InsertEnter/InsertExit for visual mode, and the only way to fire an event to change the mode color for visual mode is by tweaking the key mappings to change the mode color upon visual mode enter/exit.
