### PR TITLE
Add NeoVim support for servername.

### DIFF
--- a/after/plugin/neatstatus.vim
+++ b/after/plugin/neatstatus.vim
@@ -118,8 +118,12 @@ if has('statusline')
 
         " Determine the name of the session or terminal
         if (strlen(v:servername)>0)
-            " If running a GUI vim with servername, then use that
-            let g:neatstatus_session = v:servername
+            if v:servername =~ 'nvim'
+                let g:neatstatus_session = 'neovim'
+            else
+                " If running a GUI vim with servername, then use that
+                let g:neatstatus_session = v:servername
+            endif
         elseif !has('gui_running')
             " If running CLI vim say TMUX or use the terminal name.
             if (exists("$TMUX"))


### PR DESCRIPTION
NeoVim has a crazy value that comes back from v:servername (i.e. `/var/folders/yw/csycvz5d29l5lmn3bcr897200000gn/T/nvimTsRb2k/0`). This change looks for `nvim` in the variable, and if it finds it, simply puts `neovim` in the session variable.
